### PR TITLE
Add option to use absolute source paths on babel transformation

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -16,6 +16,7 @@ program
     .option('-w, --watch', 'watch for changes and recompile')
     .option('-b, --bytecode', 'output bytecode')
     .option('-c, --compress', 'compress using UglifyJS2')
+    .option('-a, --use-absolute-paths', 'use absolute source paths')
     .parse(process.argv);
 
 const inputModule = program.args[0];
@@ -28,6 +29,7 @@ const options = {
   target: program.target,
   bytecode: !!program.bytecode,
   compress: !!program.compress,
+  useAbsolutePaths: !!program.useAbsolutePaths
 };
 
 if (!watch) {

--- a/index.js
+++ b/index.js
@@ -199,6 +199,7 @@ function compile(entrypoint, cache, options) {
 
     if (options.target !== 'V8') {
       b.transform('babelify', {
+        sourceMapsAbsolute: !!options.useAbsolutePaths,
         presets: ['es2015']
       });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frida-compile",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "authors": [
     "Frida Developers"
   ],


### PR DESCRIPTION
Helps debuggers that could have trouble resolving relative paths