### PR TITLE
Set basedir relative to frida-compile so source path refs are correct

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ function compile(entrypoint, cache, options) {
     const inputs = new Set();
 
     const b = browserify(entrypoint, {
-      basedir: (path.extname(entrypoint) === '.js') ? path.dirname(entrypoint) : entrypoint,
+      basedir: process.cwd(),
       extensions: ['.js', '.json', '.cy'],
       builtins: fridaBuiltins,
       cache: cache,


### PR DESCRIPTION
frida-compile currently supports the generation of source maps in absolute and relative path configurations. 

In the relative path configuration, the root was previously set to the input file's home directory. For example, `frida-compile src/in.js -o dst/out.js` would result in a source map with simply `in.js`. This doesn't align with the paths on disk and makes the debugger's life very difficult when it comes to parsing source map refs.

Instead, we anchor to wherever frida-compile is invoked from. In the above example, `src/in.js` gets correctly encoded in the source map.