### PR TITLE
add a sourcemap option to frida-compile to enable/disable sourcemap generation

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -15,6 +15,7 @@ program
     .option('-w, --watch', 'watch for changes and recompile')
     .option('-b, --bytecode', 'output bytecode')
     .option('-x, --no-babelify', 'skip Babel transforms')
+    .option('-S, --no-sourcemap', 'omit sourcemap')
     .option('-c, --compress', 'compress using UglifyJS2')
     .option('-a, --use-absolute-paths', 'use absolute source paths')
     .parse(process.argv);
@@ -29,6 +30,7 @@ const options = {
   target: program.target,
   bytecode: !!program.bytecode,
   babelify: program.babelify,
+  sourcemap: program.sourcemap,
   compress: !!program.compress,
   useAbsolutePaths: !!program.useAbsolutePaths
 };

--- a/index.js
+++ b/index.js
@@ -149,14 +149,13 @@ function compile(entrypoint, cache, options) {
 
     const localTypesDir = path.join(path.resolve(path.dirname(entrypoint)), 'node_modules', '@types');
     const gumTypesDir = path.dirname(require.resolve('frida-gum-types'));
-
     const b = browserify(entrypoint, {
       basedir: process.cwd(),
       extensions: ['.js', '.json', '.cy', '.ts'],
       builtins: fridaBuiltins,
       ignoreTransform: !options.babelify ? ['babelify'] : [],
       cache: cache,
-      debug: true
+      debug: options.sourcemap
     })
     .plugin(tsify, {
       typeRoots: [gumTypesDir, localTypesDir],
@@ -317,6 +316,8 @@ function writeFile(file, data, options) {
 
 function trimSourceMap(molder) {
   var map = molder.sourcemap;
+  if (map === undefined)
+    return '';
   map.setProperty('sourcesContent', undefined);
   return map.toComment();
 }


### PR DESCRIPTION
This PR adds a debug option to `frida-compile` which gets passed on to browserify.
The debug option disables/enables sourcemap on the generated file. 

The reason to have such an option is to reduce the generated file's size. You could easily reduce approximately 33% file size by disabling sourcemap. 