### PR TITLE
Add `-T` to omit internal typeRoots

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -16,6 +16,7 @@ program
     .option('-b, --bytecode', 'output bytecode')
     .option('-x, --no-babelify', 'skip Babel transforms')
     .option('-S, --no-sourcemap', 'omit sourcemap')
+    .option('-T, --no-typeroots', 'omit internal type roots')
     .option('-c, --compress', 'compress using UglifyJS2')
     .option('-a, --use-absolute-paths', 'use absolute source paths')
     .parse(process.argv);
@@ -31,6 +32,7 @@ const options = {
   bytecode: !!program.bytecode,
   babelify: program.babelify,
   sourcemap: program.sourcemap,
+  typeroots: program.typeroots,
   compress: !!program.compress,
   useAbsolutePaths: !!program.useAbsolutePaths
 };

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ function compile(entrypoint, cache, options) {
       debug: options.sourcemap
     })
     .plugin(tsify, {
-      typeRoots: [gumTypesDir, localTypesDir],
+      [`${options.typeroots ? '' : '_'}typeRoots`]: [gumTypesDir, localTypesDir],
       target: 'es5',
       module: 'CommonJS',
       moduleResolution: 'node',


### PR DESCRIPTION
In this way when using `-T`, the only actual `typeRoots` are the ones specified in `tsconfig.json`. This allows for local tweaking of Frida’s type defs.