### PR TITLE
only pipe to trimSourceMap if options.sourcemap is True

### DIFF
--- a/index.js
+++ b/index.js
@@ -250,7 +250,7 @@ function compile(entrypoint, cache, options) {
       e.inputs = inputs;
       reject(e);
     })
-    .pipe(mold.transform(trimSourceMap))
+    .pipe(options.sourcemap ? mold.transform(trimSourceMap) : through.obj())
     .pipe(concat(function (buf) {
       if (options.bytecode) {
         compileToBytecode(buf.toString())


### PR DESCRIPTION
Sometimes the code generated, when sourcemap is disabled, is invalid due to being passed via trimSourceMap. This code disable pipe via trimSourceMap when sourcemap is disabled.