### PR TITLE
Remove options overriding local tsconfig.json values for tsify.

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -16,7 +16,6 @@ program
     .option('-b, --bytecode', 'output bytecode')
     .option('-x, --no-babelify', 'skip Babel transforms')
     .option('-S, --no-sourcemap', 'omit sourcemap')
-    .option('-T, --no-typeroots', 'omit internal type roots')
     .option('-c, --compress', 'compress using UglifyJS2')
     .option('-a, --use-absolute-paths', 'use absolute source paths')
     .parse(process.argv);
@@ -32,7 +31,6 @@ const options = {
   bytecode: !!program.bytecode,
   babelify: program.babelify,
   sourcemap: program.sourcemap,
-  typeroots: program.typeroots,
   compress: !!program.compress,
   useAbsolutePaths: !!program.useAbsolutePaths
 };

--- a/index.js
+++ b/index.js
@@ -163,8 +163,7 @@ function compile(entrypoint, cache, options) {
       debug: options.sourcemap
     })
     .plugin(tsify, {
-      [`${options.typeroots ? '' : '_'}typeRoots`]: [gumTypesDir, localTypesDir],
-      target: 'es5',
+      [`${options.typeroots ? '' : '_'}typeRoots`]: [gumTypesDir, localTypesDir]
     })
     .on('package', function (pkg) {
       inputs.add(path.join(pkg.__dirname, 'package.json'));

--- a/index.js
+++ b/index.js
@@ -165,9 +165,6 @@ function compile(entrypoint, cache, options) {
     .plugin(tsify, {
       [`${options.typeroots ? '' : '_'}typeRoots`]: [gumTypesDir, localTypesDir],
       target: 'es5',
-      module: 'CommonJS',
-      moduleResolution: 'node',
-      lib: ['es5', 'es2015.promise'],
     })
     .on('package', function (pkg) {
       inputs.add(path.join(pkg.__dirname, 'package.json'));

--- a/index.js
+++ b/index.js
@@ -152,8 +152,6 @@ function compile(entrypoint, cache, options) {
   return new Promise(function (resolve, reject) {
     const inputs = new Set([ entrypoint ]);
 
-    const localTypesDir = path.join(path.resolve(path.dirname(entrypoint)), 'node_modules', '@types');
-    const gumTypesDir = path.dirname(require.resolve('frida-gum-types'));
     const b = browserify(entrypoint, {
       basedir: process.cwd(),
       extensions: ['.js', '.json', '.cy', '.ts'],
@@ -162,9 +160,7 @@ function compile(entrypoint, cache, options) {
       cache: cache,
       debug: options.sourcemap
     })
-    .plugin(tsify, {
-      [`${options.typeroots ? '' : '_'}typeRoots`]: [gumTypesDir, localTypesDir]
-    })
+    .plugin(tsify)
     .on('package', function (pkg) {
       inputs.add(path.join(pkg.__dirname, 'package.json'));
     })

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "frida-any-promise": "^1.0.2",
     "frida-buffer": "^1.0.3",
     "frida-fs": "^1.2.1",
-    "frida-gum-types": "^1.0.5",
     "frida-http": "^1.0.2",
     "frida-net": "^1.2.5",
     "frida-process": "^1.0.2",


### PR DESCRIPTION
With these options hard coded, options such as `lib` specified in a `tsconfig.json` file are overridden causing `frida-compile` to fail on projects that require other libraries such as `es2015.proxy`.

I am unsure about the target key, but I guess this should be removed too if you are targeting v8.