### PR TITLE
Fix CVE-2020-7789 by upgrading node-notifier dependency to 8.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "frida-net": "^3.0.1",
     "frida-process": "^3.0.1",
     "mold-source-map": "^0.4.0",
-    "node-notifier": "^8.0.0",
+    "node-notifier": "^8.0.1",
     "through2": "^4.0.2",
     "tsify": "^5.0.2",
     "typescript": "^4.0.2"


### PR DESCRIPTION
![Screenshot 2020-12-27 at 00 27 36](https://user-images.githubusercontent.com/6431515/103160912-e1b35100-47da-11eb-9cec-a829c8ad1072.png)
