### PR TITLE
Add an option to specify a tsconfig.json file

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -15,6 +15,7 @@ program
     .option('-S, --no-sourcemap', 'omit sourcemap')
     .option('-c, --compress', 'compress using UglifyJS2')
     .option('-a, --use-absolute-paths', 'use absolute source paths')
+    .option('-t, --tsconfig <file>', 'path to a tsconfig <file> to use when compiling TypeScript files')
     .parse(process.argv);
 
 const inputModule = program.args[0];
@@ -28,7 +29,8 @@ const options = {
   bytecode: !!program.bytecode,
   sourcemap: program.sourcemap,
   compress: !!program.compress,
-  useAbsolutePaths: !!program.useAbsolutePaths
+  useAbsolutePaths: !!program.useAbsolutePaths,
+  tsconfig: program.tsconfig
 };
 
 if (!watch) {

--- a/index.js
+++ b/index.js
@@ -203,7 +203,8 @@ function makeCompiler(entrypoint, cache, options) {
     debug: options.sourcemap
   })
   .plugin(tsify, {
-    forceConsistentCasingInFileNames: true
+    forceConsistentCasingInFileNames: true,
+    project: options.tsconfig
   })
   .on('package', pkg => {
     inputs.add(path.join(pkg.__dirname, 'package.json'));


### PR DESCRIPTION
## Description
When compiling a TypeScript file with frida-compile, the tsify plugin for browserify will currently default to using the `tsconfig.json` file found in the current working directory (where the tool is running from). I have a use case where I would like to use the frida-compile package in an utility I am working on and be able to compile scripts located anywhere on the filesystem (outside of my package) and specify where the `tsconfig.json` file is located.

## Change
- Added a new `tsconfig` to the `options` dictionary to contain the path or the contents of a `tsconfig.json` file.
- Added a new flag `--tsconfig` to the CLI 

## Screenshots
### New flag
![new flag](https://user-images.githubusercontent.com/16500627/109716096-5f486400-7b72-11eb-83ab-fc44c78882df.png)

### Compiling TypeScript files outside of the package directory before and after the flag
![update](https://user-images.githubusercontent.com/16500627/109714782-d250db00-7b70-11eb-96a4-1e36833ec841.png)

