### PR TITLE
Expose browserify's standalone option

### DIFF
--- a/bin/compile.js
+++ b/bin/compile.js
@@ -16,6 +16,7 @@ program
     .option('-c, --compress', 'compress using UglifyJS2')
     .option('-a, --use-absolute-paths', 'use absolute source paths')
     .option('-t, --tsconfig <file>', 'path to a tsconfig <file> to use when compiling TypeScript files')
+    .option('-s, --standalone <name>', "export the agent's contents under the external module <name>")
     .parse(process.argv);
 
 const inputModule = program.args[0];
@@ -30,7 +31,8 @@ const options = {
   sourcemap: program.sourcemap,
   compress: !!program.compress,
   useAbsolutePaths: !!program.useAbsolutePaths,
-  tsconfig: program.tsconfig
+  tsconfig: program.tsconfig,
+  standalone: program.standalone
 };
 
 if (!watch) {

--- a/index.js
+++ b/index.js
@@ -200,7 +200,8 @@ function makeCompiler(entrypoint, cache, options) {
     extensions: ['.js', '.json', '.cy', '.ts'],
     builtins: fridaBuiltins,
     cache: cache,
-    debug: options.sourcemap
+    debug: options.sourcemap,
+    standalone: options.standalone
   })
   .plugin(tsify, {
     forceConsistentCasingInFileNames: true,


### PR DESCRIPTION
This allows you to easily expose some of the agent's functionality for use in the REPL:

```
// index.ts
export function foo() {
    console.log('bar!');
}
```
`$ frida-compile index.ts -s agent -o _agent.js`

`$ frida -f /bin/ls -l _agent.js`
```
[Local::ls]-> agent.foo()
bar!
```