### PR TITLE
Ensure browser switch is off.

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,7 +201,8 @@ function makeCompiler(entrypoint, cache, options) {
     builtins: fridaBuiltins,
     cache: cache,
     debug: options.sourcemap,
-    standalone: options.standalone
+    standalone: options.standalone,
+    browserField: false
   })
   .plugin(tsify, {
     forceConsistentCasingInFileNames: true,


### PR DESCRIPTION
When this is enabled, `browserify` will only require `browser` based files specified in the `package.json` file. This generally will lead to improper imports for frida scripts.

Per the `browserify` docs this should be used when utilizing it from node;
https://github.com/browserify/browserify/blob/0ec6e80ec48b67513718a392a6d09bd5569967d4/bin/advanced.txt#L54-L57

This will verify likely close the issues described in #30 