### PR TITLE
Bundle dependencies source maps

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -526,9 +526,19 @@ function createBundler(entrypoint: EntrypointName, projectRoot: string, assets: 
                     const lines = code.split("\n");
                     const n = lines.length;
                     const lastLine = lines[n - 1];
-                    if (lastLine.startsWith("//# sourceMappingURL=")) {
-                        const precedingLines = lines.slice(0, n - 1);
-                        code = precedingLines.join("\n");
+
+                    const sourceMapToken = "//# sourceMappingURL=";
+                    if (lastLine.startsWith(sourceMapToken)) {
+                      const precedingLines = lines.slice(0, n - 1);
+                      code = precedingLines.join("\n");
+                      
+                      const souceMapDirectory = crosspath.dirname(name);
+                      const souceMapRelativePath = lastLine.substring(sourceMapToken.length);
+                      const souceMapPath = crosspath.join(souceMapDirectory, souceMapRelativePath);
+
+                      if (!output.has(souceMapPath)) {
+                        output.set(souceMapPath, system.readFile("." + souceMapPath));
+                      }
                     }
 
                     if (compression === "terser") {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -539,12 +539,12 @@ function createBundler(entrypoint: EntrypointName, projectRoot: string, assets: 
 
                         const sourceMapPath = isInlined ? 
                             `${name}.map` : 
-                            `.${crosspath.join(crosspath.dirname(name), inlinedSourceMapOrPath)}`;
+                            crosspath.join(crosspath.dirname(name), inlinedSourceMapOrPath);
 
                         if (!output.has(sourceMapPath)) {
                             const content = isInlined ? 
                                 system.base64decode(inlinedSourceMapOrPath.substring(dataUrlToken.length)) :
-                                system.readFile(sourceMapPath);
+                                system.readFile(`.${sourceMapPath}`);
 
                             output.set(sourceMapPath, content);
                         }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -542,9 +542,9 @@ function createBundler(entrypoint: EntrypointName, projectRoot: string, assets: 
                             : crosspath.join(crosspath.dirname(name), inlinedSourceMapOrPath);
 
                         if (!output.has(sourceMapPath)) {
-                            const content = isInlined ? 
-                                system.base64decode(inlinedSourceMapOrPath.substring(dataUrlToken.length)) :
-                                system.readFile(`.${sourceMapPath}`);
+                            const content = isInlined
+                                ? system.base64decode(inlinedSourceMapOrPath.substring(dataUrlToken.length))
+                                : system.readFile(`.${sourceMapPath}`);
 
                             output.set(sourceMapPath, content);
                         }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -537,9 +537,9 @@ function createBundler(entrypoint: EntrypointName, projectRoot: string, assets: 
                         const dataUrlToken = "data:application/json;base64,";
                         const isInlined = inlinedSourceMapOrPath.startsWith(dataUrlToken);
 
-                        const sourceMapPath = isInlined ? 
-                            `${name}.map` : 
-                            crosspath.join(crosspath.dirname(name), inlinedSourceMapOrPath);
+                        const sourceMapPath = isInlined
+                            ? `${name}.map`
+                            : crosspath.join(crosspath.dirname(name), inlinedSourceMapOrPath);
 
                         if (!output.has(sourceMapPath)) {
                             const content = isInlined ? 


### PR DESCRIPTION
Hi again! 

Not sure if I've missed something, but currently, `frida-compile` doesn't seem to bundle dependencies source maps. 

~~This small change doesn't handle inlined source maps, though - let me know if you wish that to be the case~~ Done :smiley: 