### PR TITLE
Added plain option to build without the container format

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,8 @@ function main() {
         .requiredOption("-o, --output <file>", "write output to <file>")
         .option("-w, --watch", "watch for changes and recompile")
         .option("-S, --no-source-maps", "omit source-maps")
-        .option("-c, --compress", "compress using terser");
+        .option("-c, --compress", "compress using terser")
+        .option("-p, --plain", "plain output without container");
 
     program.parse();
 
@@ -33,6 +34,7 @@ function main() {
         entrypoint,
         sourceMaps: opts.sourceMaps ? "included" : "omitted",
         compression: opts.compress ? "terser" : "none",
+        plain: opts.plain ? true : false,
         assets,
         system
     };


### PR DESCRIPTION
I noticed as well in issue #71 it's mentioned that evaluating scripts doesn't seem to work with the container format. I wasn't able to find a way to do this either thus this PR was born.

This PR adds a `-p` flag to build plainly without the container where when combined with `-S` builds a basic output file that can be eval'd.