### PR TITLE
Bundle dependencies source maps

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -526,9 +526,30 @@ function createBundler(entrypoint: EntrypointName, projectRoot: string, assets: 
                     const lines = code.split("\n");
                     const n = lines.length;
                     const lastLine = lines[n - 1];
-                    if (lastLine.startsWith("//# sourceMappingURL=")) {
+
+                    const sourceMapToken = "//# sourceMappingURL=";
+                    if (lastLine.startsWith(sourceMapToken)) {
                         const precedingLines = lines.slice(0, n - 1);
                         code = precedingLines.join("\n");
+
+                        const inlinedSourceMapOrPath = lastLine.substring(sourceMapToken.length);
+
+                        const dataUrlToken = "data:application/json;base64,";
+                        const isInlined = inlinedSourceMapOrPath.startsWith(dataUrlToken);
+
+                        const sourceMapPath = isInlined
+                            ? `${name}.map`
+                            : crosspath.join(crosspath.dirname(name), inlinedSourceMapOrPath);
+
+                        if (!output.has(sourceMapPath)) {
+                            const content = isInlined
+                                ? system.base64decode?.(inlinedSourceMapOrPath.substring(dataUrlToken.length))
+                                : system.readFile(`.${sourceMapPath}`);
+                            
+                            if (content !== undefined) {
+                                output.set(sourceMapPath, content);
+                            }                            
+                        }
                     }
 
                     if (compression === "terser") {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -546,10 +546,10 @@ function createBundler(entrypoint: EntrypointName, projectRoot: string, assets: 
                                 const content = isInlined
                                     ? system.base64decode?.(inlinedSourceMapOrPath.substring(dataUrlToken.length))
                                     : system.readFile(`.${sourceMapPath}`);
-                                
+
                                 if (content !== undefined) {
                                     output.set(sourceMapPath, content);
-                                }                            
+                                }
                             }
                         }
                     }

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -532,23 +532,25 @@ function createBundler(entrypoint: EntrypointName, projectRoot: string, assets: 
                         const precedingLines = lines.slice(0, n - 1);
                         code = precedingLines.join("\n");
 
-                        const inlinedSourceMapOrPath = lastLine.substring(sourceMapToken.length);
+                        if (sourceMaps === "included") {
+                            const inlinedSourceMapOrPath = lastLine.substring(sourceMapToken.length);
 
-                        const dataUrlToken = "data:application/json;base64,";
-                        const isInlined = inlinedSourceMapOrPath.startsWith(dataUrlToken);
+                            const dataUrlToken = "data:application/json;base64,";
+                            const isInlined = inlinedSourceMapOrPath.startsWith(dataUrlToken);
 
-                        const sourceMapPath = isInlined
-                            ? `${name}.map`
-                            : crosspath.join(crosspath.dirname(name), inlinedSourceMapOrPath);
+                            const sourceMapPath = isInlined
+                                ? `${name}.map`
+                                : crosspath.join(crosspath.dirname(name), inlinedSourceMapOrPath);
 
-                        if (!output.has(sourceMapPath)) {
-                            const content = isInlined
-                                ? system.base64decode?.(inlinedSourceMapOrPath.substring(dataUrlToken.length))
-                                : system.readFile(`.${sourceMapPath}`);
-                            
-                            if (content !== undefined) {
-                                output.set(sourceMapPath, content);
-                            }                            
+                            if (!output.has(sourceMapPath)) {
+                                const content = isInlined
+                                    ? system.base64decode?.(inlinedSourceMapOrPath.substring(dataUrlToken.length))
+                                    : system.readFile(`.${sourceMapPath}`);
+                                
+                                if (content !== undefined) {
+                                    output.set(sourceMapPath, content);
+                                }                            
+                            }
                         }
                     }
 


### PR DESCRIPTION
Alright, it was a matter of an optional chaining - not sure how I missed that.

I didn't add a workaround in case `base64decode` is undefined because [it should always be defined on node](https://github.com/microsoft/TypeScript/blob/a614119c1921ca61d549a7eee65c0b8c69c28752/src/compiler/sys.ts#L1560).

I confirm I can successfully compile and build using:
```sh
git clone https://github.com/vfsfitvnm/frida-compile.git
cd frida-compile
git submodule init
git submodule update
sed -i -e 's/import pkg from ".\/package.json" assert {type: "json"}\;/import {readFileSync} from "fs"\;\nconst pkg = JSON.parse(readFileSync(".\/package.json", {encoding: "utf8"}))\;/g' ext/cjstoesm/rollup.config.mjs
make

mkdir ../frida-il2cpp-bridge-example && cd "$_"
npm init --yes
echo 'import "frida-il2cpp-bridge";' > index.js
npm i -D ../frida-compile @types/frida-gum frida-il2cpp-bridge
npm exec frida-compile -- -o out.js index.js
```
