### PR TITLE
Fix to ensure module map data can be omitted correctly

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -348,8 +348,11 @@ function makeCompilerOptions(projectRoot: string, system: ts.System, options: Ou
     if (options.sourceMaps === "included") {
         opts.sourceRoot = projectRoot;
         opts.sourceMap = true;
-        opts.inlineSourceMap = false;
+    } else {
+        opts.sourceRoot = undefined;
+        opts.sourceMap = false;
     }
+    opts.inlineSourceMap = false;
 
     return opts;
 }


### PR DESCRIPTION
Currently module map data is written out to the JS irrespective of whether `-S` is used.
This PR addresses this and correctly produces JS without the module map data embedded within.