### PR TITLE
Use ES2022 module and bundler resolution for ESM compatibility

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -361,7 +361,8 @@ export function makeDefaultCompilerOptions(): ts.CompilerOptions {
     return {
         target: ts.ScriptTarget.ES2022,
         lib: ["lib.es2022.d.ts"],
-        module: ts.ModuleKind.Node16,
+        module: ts.ModuleKind.ES2022,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
         allowSyntheticDefaultImports: true,
         resolveJsonModule: true,
         allowJs: true,


### PR DESCRIPTION
Update default compiler options to use ES2022 module and bundler resolution for ESM compatibility

Affects both Android and iOS:
Android: https://github.com/frida/frida/issues/3467
iOS: https://github.com/frida/frida/issues/3466