### PR TITLE
compiler: use esm

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -361,7 +361,7 @@ export function makeDefaultCompilerOptions(): ts.CompilerOptions {
     return {
         target: ts.ScriptTarget.ES2022,
         lib: ["lib.es2022.d.ts"],
-        module: ts.ModuleKind.Node16,
+        module: ts.ModuleKind.ESNext,
         allowSyntheticDefaultImports: true,
         resolveJsonModule: true,
         allowJs: true,


### PR DESCRIPTION
frida 17 now moves to ESM.

I noticed that there is a error about my `tsconfig.json` for script agents:

> tsconfig.json:10:25 - error TS5109: Option 'moduleResolution' must be set to 'Node16' (or left unspecified) when option 'module' is set to 'Node16'.

Even when I manually updated tsconfig to:

```json
{
    "module": "esnext",
    "moduleResolution": "node"
}
```

It still got overridden by `frida-compile`'s hardcoded config.

If I kept the old node16 configuration, there will be the following error in bundled script

> ReferenceError: 'exports' is not defined

So I think esnext should be the intended config here